### PR TITLE
Migrate import path from code.google.com to golang.org

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -3,7 +3,7 @@ package gohtml
 import (
 	"strings"
 
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 )
 
 // parse parses a stirng and converts it into an html.


### PR DESCRIPTION
"go get" now gives this warning: code.google.com is shutting down;
import path code.google.com/p/go.net/html will stop working

----

Thank you @yosssi!