### PR TITLE
FormatBytes

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -8,7 +8,12 @@ import (
 
 // Format parses the input HTML string, formats it and returns the result.
 func Format(s string) string {
-	return parse(s).html()
+	return parse(strings.NewReader(s)).html()
+}
+
+// FormatBytes parses input HTML as bytes, formats it and returns the result.
+func FormatBytes(b []byte) []byte {
+	return parse(bytes.NewReader(b)).bytes()
 }
 
 // Format parses the input HTML string, formats it and returns the result with line no.

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -2,10 +2,9 @@ package gohtml
 
 import "testing"
 
-func TestFormat(t *testing.T) {
-	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/></body></html> <!-- aaa -->`
-	actual := Format(s)
-	expected := `<!DOCTYPE html>
+const (
+	unformattedHTML = `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/></body></html> <!-- aaa -->`
+	formattedHTML   = `<!DOCTYPE html>
 <html>
   <head>
     <title>
@@ -22,14 +21,24 @@ func TestFormat(t *testing.T) {
   </body>
 </html>
 <!-- aaa -->`
-	if actual != expected {
-		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
+)
+
+func TestFormat(t *testing.T) {
+	actual := Format(unformattedHTML)
+	if actual != formattedHTML {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", formattedHTML, actual)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	actual := string(FormatBytes([]byte(unformattedHTML)))
+	if actual != formattedHTML {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", formattedHTML, actual)
 	}
 }
 
 func TestFormatWithLineNo(t *testing.T) {
-	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/></body></html> <!-- aaa -->`
-	actual := FormatWithLineNo(s)
+	actual := FormatWithLineNo(unformattedHTML)
 	expected := ` 1  <!DOCTYPE html>
  2  <html>
  3    <head>

--- a/html_document.go
+++ b/html_document.go
@@ -9,11 +9,16 @@ type htmlDocument struct {
 
 // html generates an HTML source code and returns it.
 func (htmlDoc *htmlDocument) html() string {
+	return string(htmlDoc.bytes())
+}
+
+// bytes reads from htmlDocument's internal array of elements and returns HTML source code
+func (htmlDoc *htmlDocument) bytes() []byte {
 	bf := &bytes.Buffer{}
 	for _, e := range htmlDoc.elements {
 		e.write(bf, startIndent)
 	}
-	return bf.String()
+	return bf.Bytes()
 }
 
 // append appends an element to the htmlDocument.

--- a/html_document_test.go
+++ b/html_document_test.go
@@ -1,10 +1,13 @@
 package gohtml
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestHTMLDocumentHTML(t *testing.T) {
 	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/></body></html><!-- aaa -->`
-	htmlDoc := parse(s)
+	htmlDoc := parse(strings.NewReader(s))
 	actual := htmlDoc.html()
 	expected := `<!DOCTYPE html>
 <html>

--- a/parser.go
+++ b/parser.go
@@ -1,15 +1,15 @@
 package gohtml
 
 import (
-	"strings"
-
 	"golang.org/x/net/html"
+	"io"
+	"strings"
 )
 
 // parse parses a stirng and converts it into an html.
-func parse(s string) *htmlDocument {
+func parse(r io.Reader) *htmlDocument {
 	htmlDoc := &htmlDocument{}
-	tokenizer := html.NewTokenizer(strings.NewReader(s))
+	tokenizer := html.NewTokenizer(r)
 	for {
 		if errorToken, _, _ := parseToken(tokenizer, htmlDoc, nil); errorToken {
 			break

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,10 +1,13 @@
 package gohtml
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParse(t *testing.T) {
 	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/></body></html><!-- aaa --><a>`
-	htmlDoc := parse(s)
+	htmlDoc := parse(strings.NewReader(s))
 	actual := htmlDoc.html()
 	expected := `<!DOCTYPE html>
 <html>


### PR DESCRIPTION
If the user already has a byte array they can avoid needing to convert it to `string` with `FormatBytes`.

Thanks for the consideration!