### PR TITLE
Added Condense option, supressed test output

### DIFF
--- a/html_document_test.go
+++ b/html_document_test.go
@@ -8,6 +8,7 @@ import (
 func TestHTMLDocumentHTML(t *testing.T) {
 	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/></body></html><!-- aaa -->`
 	htmlDoc := parse(strings.NewReader(s))
+
 	actual := htmlDoc.html()
 	expected := `<!DOCTYPE html>
 <html>
@@ -37,5 +38,34 @@ func TestHTMLDocumentAppend(t *testing.T) {
 	htmlDoc.append(textElem)
 	if len(htmlDoc.elements) != 1 || htmlDoc.elements[0] != textElem {
 		t.Errorf("htmlDocument.elements is invalid. [expected: %+v][actual: %+v]", []element{textElem}, htmlDoc.elements)
+	}
+}
+
+func TestCondense(t *testing.T) {
+	Condense = true
+	defer func() {
+		Condense = false
+	}()
+	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><p>A Single Line</p><br/></body></html><!-- aaa -->`
+	htmlDoc := parse(strings.NewReader(s))
+	actual := htmlDoc.html()
+	expected := `<!DOCTYPE html>
+<html>
+  <head>
+    <title>This is a title.</title>
+  </head>
+  <body>
+    <p>
+      Line1
+      <br>
+      Line2
+    </p>
+    <p>A Single Line</p>
+    <br/>
+  </body>
+</html>
+<!-- aaa -->`
+	if actual != expected {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -6,10 +6,12 @@ import (
 )
 
 // writeLine writes an HTML line to the buffer.
-func writeLine(bf *bytes.Buffer, s string, indent int) {
+func writeLine(bf *bytes.Buffer, indent int, strs ...string) {
 	writeLineFeed(bf)
 	writeIndent(bf, indent)
-	bf.WriteString(s)
+	for _, s := range strs {
+		bf.WriteString(s)
+	}
 }
 
 // writeLineFeed writes a line feed to the buffer.

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestWriteLine(t *testing.T) {
 	bf := &bytes.Buffer{}
-	writeLine(bf, "test", 1)
+	writeLine(bf, 1, "test")
 	actual := bf.String()
 	expected := defaultIndentString + "test"
 	if actual != expected {
@@ -17,7 +17,7 @@ func TestWriteLine(t *testing.T) {
 
 func TestWriteLineFeed(t *testing.T) {
 	bf := &bytes.Buffer{}
-	writeLine(bf, "test", 0)
+	writeLine(bf, 0, "test")
 	writeLineFeed(bf)
 	actual := bf.String()
 	expected := "test\n"

--- a/writer_test.go
+++ b/writer_test.go
@@ -2,12 +2,12 @@ package gohtml
 
 import (
 	"bytes"
-	"os"
 	"testing"
 )
 
 func TestWriterSetLastElement(t *testing.T) {
-	wr := NewWriter(os.Stdout)
+	buf := &bytes.Buffer{}
+	wr := NewWriter(buf)
 	wr.SetLastElement("test")
 	if wr.lastElement != "test" {
 		t.Errorf("Invalid lastElement. [expected: %s][actual: %s]", "test", wr.lastElement)
@@ -15,7 +15,8 @@ func TestWriterSetLastElement(t *testing.T) {
 }
 
 func TestWriterWrite(t *testing.T) {
-	wr := NewWriter(os.Stdout)
+	buf := &bytes.Buffer{}
+	wr := NewWriter(buf)
 	n, err := wr.Write([]byte("<html><head><title>This is a title.</title></head><body><p>test</p></body></html>"))
 	if err != nil {
 		t.Errorf("An error occurred. [error: %s]", err.Error())
@@ -25,7 +26,8 @@ func TestWriterWrite(t *testing.T) {
 		t.Errorf("Invalid return value. [expected: %d][actual: %d]", expected, n)
 	}
 
-	wr = NewWriter(os.Stdout)
+	buf = &bytes.Buffer{}
+	wr = NewWriter(buf)
 	n, err = wr.Write([]byte(""))
 	if err != nil {
 		t.Errorf("An error occurred. [error: %s]", err.Error())
@@ -37,8 +39,9 @@ func TestWriterWrite(t *testing.T) {
 }
 
 func TestNewWriter(t *testing.T) {
-	wr := NewWriter(os.Stdout)
-	if wr.writer != os.Stdout || wr.lastElement != defaultLastElement || wr.bf.Len() != 0 {
-		t.Errorf("Invalid Writer. [expected: %+v][actual: %+v]", &Writer{writer: os.Stdout, lastElement: defaultLastElement, bf: &bytes.Buffer{}}, wr)
+	buf := &bytes.Buffer{}
+	wr := NewWriter(buf)
+	if wr.writer != buf || wr.lastElement != defaultLastElement || wr.bf.Len() != 0 {
+		t.Errorf("Invalid Writer. [expected: %+v][actual: %+v]", &Writer{writer: buf, lastElement: defaultLastElement, bf: &bytes.Buffer{}}, wr)
 	}
 }


### PR DESCRIPTION
Condense puts the output of tag on a single line if it has either
no children or only a single text child. To make this more logical
writeLine was reordered to take a variadic string as the last arg.

Also changed test that was writing to stdOut.