### PR TITLE
Do not modify HTML text in parser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -24,7 +24,7 @@ func parseToken(tokenizer *html.Tokenizer, htmlDoc *htmlDocument, parent *tagEle
 	case html.ErrorToken:
 		return true, false, ""
 	case html.TextToken:
-		text := string(tokenizer.Text())
+		text := string(tokenizer.Raw())
 		if strings.TrimSpace(text) == "" {
 			break
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -45,3 +45,20 @@ func TestAppendElement(t *testing.T) {
 		t.Errorf("htmlDocument.elements is invalid. [expected: %+v][actual: %+v]", []element{textElem}, htmlDoc.elements)
 	}
 }
+
+func TestHtmlEscape(t *testing.T) {
+	s := `<!DOCTYPE html><html><body><div>0 &lt; 1. great insight! &lt;/sarcasm&gt; over&amp;out.&</div></body></html>`
+	expected := `<!DOCTYPE html>
+<html>
+  <body>
+    <div>
+      0 &lt; 1. great insight! &lt;/sarcasm&gt; over&amp;out.&
+    </div>
+  </body>
+</html>`
+	htmlDoc := parse(strings.NewReader(s))
+	actual := htmlDoc.html()
+	if actual != expected {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
+	}
+}


### PR DESCRIPTION
The parser used the html.Tokenizer Text() function will return unescaped
text resulting in invalid HTML if HTML escaping is used in the input.

By using the Raw() function the text is preserved from the input and
does not remove escaping.

fixes yosssi/gohtml#6