### PR TITLE
Trimming text nodes to remove extra newlines.

### DIFF
--- a/html_document_test.go
+++ b/html_document_test.go
@@ -69,3 +69,33 @@ func TestCondense(t *testing.T) {
 		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
 	}
 }
+
+func TestHTMLTextWithNewline(t *testing.T) {
+	s := `
+<!DOCTYPE html><html><head></head><body>
+<div>
+  <span>
+    I am content.
+  </span>
+</div>
+</body></html>
+	`
+	htmlDoc := parse(strings.NewReader(s))
+
+	actual := htmlDoc.html()
+	expected := `<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <div>
+      <span>
+        I am content.
+      </span>
+    </div>
+  </body>
+</html>`
+	if actual != expected {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -25,7 +25,8 @@ func parseToken(tokenizer *html.Tokenizer, htmlDoc *htmlDocument, parent *tagEle
 		return true, false, ""
 	case html.TextToken:
 		text := string(tokenizer.Raw())
-		if strings.TrimSpace(text) == "" {
+		text = strings.TrimSpace(text)
+		if text == "" {
 			break
 		}
 		textElement := &textElement{text: text}


### PR DESCRIPTION
The newline of the span closing tag was added to the textnode.


