### PR TITLE
Add option to change the indent string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # GoHTML - HTML formatter for Go
 
 [![wercker status](https://app.wercker.com/status/926cf3edc004271539be40d705d037bd/s "wercker status")](https://app.wercker.com/project/bykey/926cf3edc004271539be40d705d037bd)
-[![GoDoc](http://godoc.org/github.com/yosssi/gohtml?status.png)](http://godoc.org/github.com/yosssi/gohtml)
+[![GoDoc](http://godoc.org/github.com/peterszarvas94/gohtml?status.png)](http://godoc.org/github.com/peterszarvas94/gohtml)
 
 GoHTML is an HTML formatter for [Go](http://golang.org/). You can format HTML source codes by using this package.
 
 ## Install
 
 ```
-go get -u github.com/yosssi/gohtml
+go get -u github.com/peterszarvas94/gohtml
 ```
 
 ## Example
@@ -21,7 +21,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/yosssi/gohtml"
+	"github.com/peterszarvas94/gohtml"
 )
 
 func main() {
@@ -46,35 +46,35 @@ Output:
 ```html
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>
-      This is a title.
-    </title>
-    <script type="text/javascript">
-      alert('aaa');
-      if (0 < 1) {
-      	alert('bbb');
-      }
-    </script>
-    <style type="text/css">
-      body {font-size: 14px;}
-      h1 {
-      	font-size: 16px;
-      	font-weight: bold;
-      }
-    </style>
-  </head>
-  <body>
-    <form>
-      <input type="name">
-      <p>
-        AAA
-        <br>
-        BBB>
-      </p>
-    </form>
-    <!-- This is a comment. -->
-  </body>
+	<head>
+		<title>This is a title.</title>
+		<script type="text/javascript">
+			alert("aaa");
+			if (0 < 1) {
+				alert("bbb");
+			}
+		</script>
+		<style type="text/css">
+			body {
+				font-size: 14px;
+			}
+			h1 {
+				font-size: 16px;
+				font-weight: bold;
+			}
+		</style>
+	</head>
+	<body>
+		<form>
+			<input type="name" />
+			<p>
+				AAA
+				<br />
+				BBB>
+			</p>
+		</form>
+		<!-- This is a comment. -->
+	</body>
 </html>
 ```
 
@@ -88,7 +88,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/yosssi/gohtml"
+	"github.com/peterszarvas94/gohtml"
 )
 
 func main() {
@@ -156,7 +156,7 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/yosssi/gohtml"
+	"github.com/peterszarvas94/gohtml"
 )
 
 func main() {
@@ -181,16 +181,17 @@ Output:
 
 ```html
 <html>
-  <head>
-  </head>
-  <body>
-    Hello!
-  </body>
+	<head> </head>
+	<body>
+		Hello!
+	</body>
 </html>
 ```
 
 ## Basic configuration
+
 ### Condense and inline tags
+
 ```go
 // Enable condensing a tag with only inline children onto a single line, or
 // completely inlining it with sibling nodes.
@@ -212,7 +213,9 @@ gohtml.InlineTags = map[string]bool{
 // Maximum length of an opening inline tag before it's un-inlined
 gohtml.InlineTagMaxLength = 40
 ```
+
 ## Indentation string
+
 ```go
 // The indent string, defaults to two spaces
 gohtml.IndentString = "  "
@@ -220,4 +223,4 @@ gohtml.IndentString = "  "
 
 ## Docs
 
-* [GoDoc](https://godoc.org/github.com/yosssi/gohtml)
+- [GoDoc](https://godoc.org/github.com/peterszarvas94/gohtml)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,35 @@ Output:
 </html>
 ```
 
+## Basic configuration
+### Condense and inline tags
+```go
+// Enable condensing a tag with only inline children onto a single line, or
+// completely inlining it with sibling nodes.
+// Tags to be treated as inline can be set in `InlineTags`.
+// Only inline tags will be completely inlined, while other condensable tags
+// will be given their own dedicated (single) line.
+gohtml.Condense = false
+
+// Tags that are considered inline tags.
+// Note: Text nodes are always considered to be inline
+gohtml.InlineTags = map[string]bool{
+	"a":      true,
+	"code":   true,
+	"em":     true,
+	"span":   true,
+	"strong": true,
+}
+
+// Maximum length of an opening inline tag before it's un-inlined
+gohtml.InlineTagMaxLength = 40
+```
+## Indentation string
+```go
+// The indent string, defaults to two spaces
+gohtml.IndentString = "  "
+```
+
 ## Docs
 
 * [GoDoc](https://godoc.org/github.com/yosssi/gohtml)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/peterszarvas94/gohtml
+
+go 1.24.1
+
+require golang.org/x/net v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
+golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=

--- a/html_document.go
+++ b/html_document.go
@@ -5,6 +5,9 @@ import "bytes"
 // Column to wrap lines to (disabled by default)
 var LineWrapColumn = 0
 
+// The indent string, defaults to two spaces
+var IndentString = defaultIndentString
+
 // Maxmimum characters a long word can extend past LineWrapColumn without wrapping
 var LineWrapMaxSpillover = 5
 
@@ -26,7 +29,7 @@ func (htmlDoc *htmlDocument) bytes() []byte {
 		lineWrapColumn:       LineWrapColumn,
 		lineWrapMaxSpillover: LineWrapMaxSpillover,
 
-		indentString: defaultIndentString,
+		indentString: IndentString,
 		indentLevel:  startIndent,
 	}
 

--- a/html_document_test.go
+++ b/html_document_test.go
@@ -188,3 +188,42 @@ func TestPreformatting(t *testing.T) {
 		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
 	}
 }
+
+func TestIndent(t *testing.T) {
+	IndentString = "\t"
+	defer func() {
+		IndentString = defaultIndentString
+	}()
+	s := `<!DOCTYPE html><html><head><title>This is a title.</title></head><body><p>Line1<br>Line2</p><br/><div class="empty"></div></body></html><!-- aaa -->`
+	htmlDoc := parse(strings.NewReader(s))
+
+	actual := htmlDoc.html()
+	expected := `<!DOCTYPE html>
+<html>
+	<head>
+		<title>
+			This is a title.
+		</title>
+	</head>
+	<body>
+		<p>
+			Line1
+			<br>
+			Line2
+		</p>
+		<br/>
+		<div class="empty"></div>
+	</body>
+</html>
+<!-- aaa -->`
+	if actual != expected {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
+	}
+
+	// Try again to test idempotency
+	htmlDoc = parse(strings.NewReader(actual))
+	actual = htmlDoc.html()
+	if actual != expected {
+		t.Errorf("Invalid result. [expected: %s][actual: %s]", expected, actual)
+	}
+}


### PR DESCRIPTION
Example:

```go
gohtml.IndentString = "\t"
```

This will indent with tabs instead of two spaces.